### PR TITLE
feat: add support for markdown and plaintext files

### DIFF
--- a/LocalPackages/RTextExtractionService/Sources/RTextExtractionService/RTextExtractionService.swift
+++ b/LocalPackages/RTextExtractionService/Sources/RTextExtractionService/RTextExtractionService.swift
@@ -55,6 +55,11 @@ public class RTextExtractionService {
                 if let pdfText = pdfProcessingService.extractTextFromPDF(fileURL) {
                     allText.append("=== \(file.name) ===\n\(pdfText)")
                 }
+            
+            case "md", "markdown", "txt", "text":
+                if let textContent = try? String(contentsOf: fileURL, encoding: .utf8) {
+                    allText.append("=== \(file.name) ===\n\(textContent)")
+                }
                 
             case "mp3", "wav", "aiff", "m4a":
                 if let audioText = await audioTranscriptionService.transcribeAudio(fileURL) {

--- a/Raven/Features/ProjectFiles/ProjectFilesFeature.swift
+++ b/Raven/Features/ProjectFiles/ProjectFilesFeature.swift
@@ -197,7 +197,9 @@ extension ProjectFilesView.ProjectFilesFeature {
             .video,
             .mpeg4Movie,
             .appleProtectedMPEG4Video,
-            .quickTimeMovie
+            .quickTimeMovie,
+            .plainText,
+            .text
         ]
         
         panel.begin { [weak self] result in

--- a/Raven/Features/ProjectFiles/ProjectFilesView.swift
+++ b/Raven/Features/ProjectFiles/ProjectFilesView.swift
@@ -55,7 +55,9 @@ struct ProjectFilesView: View {
                     .mpeg4Movie,
                     .appleProtectedMPEG4Video,
                     .quickTimeMovie,
-                    .pdf
+                    .pdf,
+                    .plainText,
+                    .text
                 ]
             ) { result in
                 switch result {


### PR DESCRIPTION
Hey, thank you for making this! I hope these changes help you along the way.

## Summary

I added support for markdown and text files with the following extensions:

- `.md`
- `.markdown`
- `.txt`
- `.text`

## Screenshots

I tested this with copies of your own contribution guide to prove it worked.

<img width="300" src="https://github.com/user-attachments/assets/ae7dad35-5415-4378-81f1-d0a79a68b97d" />
<img width="500" src="https://github.com/user-attachments/assets/7572a205-b700-419e-b377-11f0fb0f9262" />
<img width="500" src="https://github.com/user-attachments/assets/ee458141-e5e4-43e2-a1c6-5d47e1856e08" />
